### PR TITLE
added shortid autogenerate instead of random maths string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var express = require('express');
 var mongoose = require('mongoose');
+var shortid = require('shortid');
 var app = express();
 mongoose.connect(''); // add your own url.
 var Schema = mongoose.Schema;
@@ -10,7 +11,7 @@ var Url = mongoose.model('Url', {
     },
     redirectId: {
         type: String,
-        required: true,
+        default: shortid.generate,
         unique: true
     }
 });
@@ -28,10 +29,8 @@ app.get('/', (req, res) => {
 });
 
 app.get('/make/:url', (req, res) => {
-    var id = Math.random().toString(36).substr(22);
     var url = new Url({
-        redirectTo: req.params.url,
-        redirectId: id
+        redirectTo: req.params.url
     });
     url.save((err) => {
         res.json({

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.15.0",
-    "mongoose": "^4.8.5"
+    "mongoose": "^4.8.5",
+    "shortid": "^2.2.6"
   }
 }


### PR DESCRIPTION
Just used `shortid` npm instead of generating a random string.
Works the same way.